### PR TITLE
ci:commit和PR时也构建上传，拆分构建与发版

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,12 +1,49 @@
-name: Build and Release
+name: install
 
 on:
   push:
     branches:
-      - main
-    tags:
-      - 'v*'
+      - "**"
+    paths:
+      - ".github/workflows/install.yml"
+      - ".github/cliff.toml"
+      - "assets/**"
+      - "agent/**"
+      - "tools/**"
+      - "**.py"
+      - "requirements.txt"
+      - "docs/imgs/**"
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - ".github/workflows/install.yml"
+      - ".github/cliff.toml"
+      - "assets/**"
+      - "agent/**"
+      - "tools/**"
+      - "**.py"
+      - "requirements.txt"
+      - "docs/imgs/**"
   workflow_dispatch:
+    inputs:
+      version:
+        description: Artifact version (leave empty to use the CI version)
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: Version used in artifact names
+        required: true
+        type: string
+
+concurrency:
+  group: install-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 env:
   MFAA_VERSION: v2.16.0
@@ -17,64 +54,67 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
-      is_release: ${{ steps.set_tag.outputs.is_release }}
-      is_prerelease: ${{ steps.set_tag.outputs.is_prerelease }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+          fetch-tags: true
       - id: set_tag
         run: |
-          is_release=false
-          is_prerelease=false
-          tag=""
-
-          # 只处理 push 到 main 分支的事件(commit 触发)
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            FIRST_LINE=$(echo "${{ github.event.head_commit.message }}" | head -n1)
-            if [[ "$FIRST_LINE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-              VERSION=$(echo "$FIRST_LINE" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?')
-              if [ -n "$VERSION" ]; then
-                is_release=true
-                tag="$VERSION"
-                if [[ "$VERSION" =~ -(alpha|beta|rc|pre|preview) ]]; then
-                  is_prerelease=true
-                fi
-              fi
-            fi
+          requested_version="${{ inputs.version }}"
+          if [[ -n "$requested_version" ]]; then
+            echo "tag=$requested_version" | tee -a "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          # 无有效版本号时生成 CI 标签(不发布)
-          if [ -z "$tag" ]; then
-            tag="ci-$(date +%y%m%d)"
+          latest_tag=$(git describe --tags --match "v*" --abbrev=0 2>/dev/null || true)
+          if [[ "$latest_tag" != v* ]]; then
+            latest_tag=$(curl -sX GET "https://api.github.com/repos/${{ github.repository }}/releases/latest" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | awk '/tag_name/{print $4}' FS='["]')
+          fi
+          if [[ "$latest_tag" != v* ]]; then
+            latest_tag="v0.0.0"
           fi
 
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-          echo "is_release=$is_release" >> $GITHUB_OUTPUT
-          echo "is_prerelease=$is_prerelease" >> $GITHUB_OUTPUT
+          short_sha=$(git rev-parse --short HEAD)
+          date_str=$(date +%y%m%d)
+          tag="${latest_tag}-ci.${date_str}-${short_sha}"
 
-  create_tag:
-    needs: meta
-    if: ${{ needs.meta.outputs.is_release == 'true' }}
+          echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
+
+  changelog:
+    name: Generate changelog
+    needs: [meta]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Create and push tag
+          fetch-tags: true
+          ref: ${{ github.ref }}
+
+      - name: Generate a changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        with:
+          config: .github/cliff.toml
+          args: >-
+            -vv --latest --strip header
+        env:
+          OUTPUT: CHANGES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Write changelog to announcement file
         run: |
-          TAG="${{ needs.meta.outputs.tag }}"
-          # 检查远程是否已存在该 tag
-          if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
-            echo "Tag ${TAG} already exists remotely, skipping creation."
-          else
-            git tag "${TAG}"
-            git push origin "${TAG}"
-            echo "Tag ${TAG} created and pushed."
-          fi
+          mkdir -p announcement
+          echo "${{ steps.git-cliff.outputs.content }}" > announcement/CHANGES.md
+
+      - name: Upload announcement artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: announcement
+          path: announcement/
+          if-no-files-found: error
 
   install:
     needs: [meta, changelog]
@@ -253,104 +293,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: MaaPVZ-${{ matrix.os }}-${{ matrix.arch }}
+          name: MaaPVZ-${{ matrix.os }}-${{ matrix.arch }}-${{ needs.meta.outputs.tag }}
           path: "install"
-
-  changelog:
-    name: Generate changelog
-    needs: [meta, create_tag]
-    runs-on: ubuntu-latest
-    outputs:
-      release_body: ${{ steps.git-cliff.outputs.content }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.ref }}
-
-      - name: Fetch all tags (to ensure new tag is available)
-        run: git fetch --tags
-
-      - name: Generate a changelog
-        uses: orhun/git-cliff-action@v4
-        id: git-cliff
-        with:
-          config: .github/cliff.toml
-          # 正式版：使用 tag-pattern 只匹配正式版标签，包含所有从上一个正式版以来的提交
-          # 预发布版：正常生成，只包含从上一个标签以来的提交
-          args: >-
-            -vv --latest --strip header
-            ${{ needs.meta.outputs.is_prerelease == 'false' && '--tag-pattern "^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]{6}-[a-f0-9]{7,})?$"' || '' }}
-        env:
-          OUTPUT: CHANGES.md
-          GITHUB_REPO: ${{ github.repository }}
-
-      - name: Write changelog to announcement file
-        run: |
-          mkdir -p announcement
-          echo "${{ steps.git-cliff.outputs.content }}" > announcement/CHANGES.md
-         
-
-      - name: Upload announcement artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: announcement
-          path: announcement/
-     
-      - name: Debug changelog output
-        run: |
-          echo "CHANGES.md 内容:"
-          cat CHANGES.md
-          echo "git-cliff 输出变量 content:"
-          echo "${{ steps.git-cliff.outputs.content }}"
-
-      - name: Debug latest tag info
-        run: |
-          git tag -l --sort=-v:refname
-          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "无标签")
-          echo "Latest tag (git describe): $latest_tag"
-
-  release:
-    if: ${{ needs.meta.outputs.is_release == 'true' }}
-    needs: [meta, install, changelog, create_tag]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug meta outputs
-        run: |
-          echo "is_release: ${{ needs.meta.outputs.is_release }}"
-          echo "is_prerelease: ${{ needs.meta.outputs.is_prerelease }}"
-          echo "tag: ${{ needs.meta.outputs.tag }}"
-
-      - uses: actions/download-artifact@v4
-        with:
-          path: assets
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: announcement
-          path: announcement
-
-      - run: |
-          cd assets
-          for f in *; do
-            (cd $f && zip -r ../$f-${{ needs.meta.outputs.tag }}.zip .)
-          done
-
-      - uses: softprops/action-gh-release@v3  
-        with:
-          files: |
-            assets/*
-            announcement/*
-          tag_name: ${{ needs.meta.outputs.tag }}
-          body: ${{ needs.changelog.outputs.release_body }}
-          draft: false
-          prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
-
-      - name: Trigger MirrorChyanUploading
-        shell: bash
-        run: |
-          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release.yml -f tag=${{ needs.meta.outputs.tag }}
-          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release_note.yml -f tag=${{ needs.meta.outputs.tag }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if-no-files-found: error

--- a/.github/workflows/install_apk.yml
+++ b/.github/workflows/install_apk.yml
@@ -1,53 +1,88 @@
-name: Build and Release APK
+name: install_apk
 
 on:
   push:
     branches:
-      - main
+      - "**"
+    paths:
+      - ".github/workflows/install_apk.yml"
+      - "assets/**"
+      - "agent/**"
+      - "**.py"
+      - "requirements.txt"
+      - "docs/imgs/**"
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - ".github/workflows/install_apk.yml"
+      - "assets/**"
+      - "agent/**"
+      - "**.py"
+      - "requirements.txt"
+      - "docs/imgs/**"
   workflow_dispatch:
+    inputs:
+      version:
+        description: Artifact version (leave empty to use the CI version)
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: Version used in artifact names
+        required: true
+        type: string
+
+concurrency:
+  group: install_apk-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check_version:
     runs-on: ubuntu-latest
     outputs:
-      is_release: ${{ steps.check.outputs.is_release }}
-      tag: ${{ steps.check.outputs.tag }}
       version_tag: ${{ steps.check.outputs.version_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - id: check
         run: |
-          is_release=false
-          tag=""
-          FIRST_LINE=$(echo "${{ github.event.head_commit.message }}" | head -n1)
-          if [[ "$FIRST_LINE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            VERSION=$(echo "$FIRST_LINE" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?')
-            if [ -n "$VERSION" ]; then
-              is_release=true
-              tag="$VERSION"
-            fi
+          requested_version="${{ inputs.version }}"
+          if [[ -n "$requested_version" ]]; then
+            echo "version_tag=$requested_version" | tee -a "$GITHUB_OUTPUT"
+            exit 0
           fi
-          if [ -z "$tag" ]; then
-            tag="ci-$(date +%Y%m%d-%H%M)"
+
+          latest_tag=$(git describe --tags --match "v*" --abbrev=0 2>/dev/null || true)
+          if [[ "$latest_tag" != v* ]]; then
+            latest_tag=$(curl -sX GET "https://api.github.com/repos/${{ github.repository }}/releases/latest" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | awk '/tag_name/{print $4}' FS='["]')
           fi
-          echo "is_release=$is_release" >> $GITHUB_OUTPUT
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-          echo "version_tag=$tag" >> $GITHUB_OUTPUT
+          if [[ "$latest_tag" != v* ]]; then
+            latest_tag="v0.0.0"
+          fi
+
+          short_sha=$(git rev-parse --short HEAD)
+          date_str=$(date +%y%m%d)
+          version_tag="${latest_tag}-ci.${date_str}-${short_sha}"
+
+          echo "version_tag=$version_tag" | tee -a "$GITHUB_OUTPUT"
 
   build:
     needs: check_version
-    if: needs.check_version.outputs.is_release == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout resource
         uses: actions/checkout@v4
         with:
+          submodules: true
           path: resource
 
       - name: Clone MaaFwApp
@@ -219,15 +254,4 @@ jobs:
         with:
           name: MaaPVZ-android-arm64-${{ needs.check_version.outputs.version_tag }}
           path: maafwapp/app/build/outputs/apk/debug/MaaPVZ-*.apk
-
-      - name: Create Release (only for tags)
-        if: needs.check_version.outputs.is_release == 'true'
-        uses: softprops/action-gh-release@v1
-        with:
-          files: maafwapp/app/build/outputs/apk/debug/MaaPVZ-*.apk
-          tag_name: ${{ needs.check_version.outputs.tag }}
-          name: ${{ needs.check_version.outputs.tag }}
-          draft: false
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,148 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  desktop:
+    name: Desktop builds
+    permissions:
+      contents: read
+    uses: ./.github/workflows/install.yml
+    with:
+      version: ${{ github.ref_name }}
+
+  android:
+    name: Android APK
+    permissions:
+      contents: read
+    uses: ./.github/workflows/install_apk.yml
+    with:
+      version: ${{ github.ref_name }}
+
+  changelog:
+    name: Generate changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Detect prerelease
+        id: release_type
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" =~ (alpha|beta|rc|dev|pre|preview) ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: .github/cliff.toml
+          # 正式版：使用 tag-pattern 只匹配正式版标签，包含所有从上一个正式版以来的提交
+          # 预发布版：正常生成，只包含从上一个标签以来的提交
+          args: >-
+            -vv --latest --strip header
+            ${{ steps.release_type.outputs.is_prerelease == 'false' && '--tag-pattern "^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]{6}-[a-f0-9]{7,})?$"' || '' }}
+        env:
+          OUTPUT: CHANGES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-changelog-${{ github.ref_name }}
+          path: CHANGES.md
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub Release
+    needs: [desktop, android, changelog]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: MaaPVZ-win-*-${{ github.ref_name }}
+          path: release-assets/desktop
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: MaaPVZ-macos-*-${{ github.ref_name }}
+          path: release-assets/desktop
+
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: MaaPVZ-linux-*-${{ github.ref_name }}
+          path: release-assets/desktop
+
+      - name: Download Android APK
+        uses: actions/download-artifact@v4
+        with:
+          name: MaaPVZ-android-arm64-${{ github.ref_name }}
+          path: release-assets/android
+
+      - name: Download changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: release-changelog-${{ github.ref_name }}
+          path: release-assets/changelog
+
+      - name: Package desktop artifacts
+        shell: bash
+        run: |
+          shopt -s nullglob
+          for directory in release-assets/desktop/*; do
+            name=$(basename "$directory")
+            (cd "$directory" && zip -r "../../../$name.zip" .)
+          done
+
+      - name: Detect prerelease
+        id: release_type
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" =~ (alpha|beta|rc|dev|pre|preview) ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          body_path: release-assets/changelog/CHANGES.md
+          draft: false
+          prerelease: ${{ steps.release_type.outputs.is_prerelease == 'true' }}
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          files: |
+            MaaPVZ-*.zip
+            release-assets/android/*.apk
+
+      - name: Trigger MirrorChyan workflows
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run --repo "$GITHUB_REPOSITORY" mirrorchyan_release.yml -f tag="${{ github.ref_name }}"
+          gh workflow run --repo "$GITHUB_REPOSITORY" mirrorchyan_release_note.yml -f tag="${{ github.ref_name }}"

--- a/.gitignore
+++ b/.gitignore
@@ -459,3 +459,4 @@ tools/ImageCropper/**/*.png
 config
 debug
 .venv
+.DS_Store


### PR DESCRIPTION
install/install_apk 在所有分支 push 和 PR 时构建并上传 artifact；新增 release 工作流仅在 v* tag 时发版并触发 MirrorChyan；修复 Android APK 在普通 push 时不构建的问题