### PR TITLE
fix: 修复红水晶确定点击和领取循环

### DIFF
--- a/assets/resource/pipeline/video_card/video_card_red_crystal.json
+++ b/assets/resource/pipeline/video_card/video_card_red_crystal.json
@@ -83,7 +83,7 @@
             }
         ],
         "action": "Click",
-        "post_wait_freezes": 500,
+        "post_delay": 500,
         "next": [
             "红水晶_确定"
         ]
@@ -101,8 +101,15 @@
             62
         ],
         "action": "Click",
-        "post_wait_freezes": 500,
+        "target": [
+            544,
+            552,
+            192,
+            62
+        ],
+        "post_delay": 500,
         "next": [
+            "红水晶_计数",
             "有免广告卡_前置检查"
         ]
     }


### PR DESCRIPTION
## 问题

- 红水晶识别到“确定”后，实际点击没有生效
- 红水晶只领取一次，没有继续循环
- 观看广告后的画面等待可能超时

## 修复

- 为“确定”节点指定点击区域
- 将画面静止等待改为固定延迟
- “确定”后返回计数节点，继续后续领取